### PR TITLE
Adapting to coq-8.5rc1 (refine)

### DIFF
--- a/flocq/Calc/Fcalc_round.v
+++ b/flocq/Calc/Fcalc_round.v
@@ -646,7 +646,7 @@ case Zlt_bool_spec ; intros Hk.
 (* *)
 unfold truncate_aux.
 rewrite Fx at 1.
-refine (let H := _ in conj _ H).
+unshelve refine (let H := _ in conj _ H).
 unfold k. ring.
 rewrite <- H.
 apply F2R_eq_compat.


### PR DESCRIPTION
The last minute changes in refine in coq-8.5rc1 introduced an incompatibility. A single line is concerned.
